### PR TITLE
Updated install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 * Download Arduino 1.5 here: [http://arduino.cc](http://arduino.cc/en/Main/Software)  
   (on osx remember to open arduino first to make gatekeeper perform its magic)  
 
-* Copy the RFduino directory from this repository in Arduino  
-  (on Windows, C:\arduino-1.5.4\hardware\arduino)  
-  (on OSX, /Applications/Arduino.app/Contents/Resources/Java/hardware/arduino)  
+* Create a new directory inside the Sketch directory called "hardware"
+  inside this new directory create another directory called "RFduino"
+  Copy the RFduino directory from this repository into that directory
+  (on Windows, "My Documents\Arduino\hardware\RFduino")  
+  (on OSX, "Documents/Arduino/hardware/RFduino")  
   or "git clone https://github.com/RFduino/RFduino" in the directory indicated
 
 * Install the FTDI drivers from here: [http://ftdichip.com](http://www.ftdichip.com/Drivers/VCP.htm)

--- a/platform.txt
+++ b/platform.txt
@@ -19,7 +19,7 @@ compiler.elf2hex.flags=-O ihex
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
 compiler.ldflags=
 compiler.size.cmd=arm-none-eabi-size
-size.script.path={runtime.ide.path}/hardware/arduino/RFduino
+size.script.path={runtime.hardware.path}/RFduino
 size.script.cmd=size
 size.script.cmd.windows=size.bat
 compiler.define=-DARDUINO=
@@ -59,5 +59,5 @@ tools.RFDLoader.cmd=RFDLoader
 tools.RFDLoader.cmd.windows=RFDLoader.exe
 tools.RFDLoader.upload.params.verbose=
 tools.RFDLoader.upload.params.quiet=
-tools.RFDLoader.path={runtime.ide.path}/hardware/arduino/RFduino
+tools.RFDLoader.path={runtime.hardware.path}/RFduino
 tools.RFDLoader.upload.pattern="{path}/{cmd}" -q {serial.port} "{build.path}/{build.project_name}.hex"


### PR DESCRIPTION
The original install documentation calls to install the new hardware files into the Arduino application directory. Under OSX this will cause the hardware files to be removed when the Arduino application is updated. The user's Sketch directory should be used to store hardware files so that they are preserved across updates.

The patch updates the documentation to describe installation into the user's Sketch directory rather than the Arduino application directory. 

The creation of the second RFduino directory inside the hardware directory is very important, otherwise the hardware files will not be scanned.

platform.txt also required updating so the RFDLoader and size were prefixed with the correct paths. This change should be backward compatible with the old install documentation.