### PR TITLE
Remove dependence on UIKit; fix use of deprecated UUID attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/iPhone Apps/rfduino/RFduinoManagerDelegate.h
+++ b/iPhone Apps/rfduino/RFduinoManagerDelegate.h
@@ -39,5 +39,6 @@
 - (void)didConnectRFduino:(RFduino *)rfduino;
 - (void)didLoadServiceRFduino:(RFduino *)rfduino;
 - (void)didDisconnectRFduino:(RFduino *)rfduino;
+- (void)shouldDisplayAlertTitled:(NSString *)title messageBody:(NSString *)body;
 
 @end

--- a/iPhone Apps/rfduino/RfduinoManager.m
+++ b/iPhone Apps/rfduino/RfduinoManager.m
@@ -98,7 +98,9 @@ static CBUUID *service_uuid;
             
     }
 
-    [delegate shouldDisplayAlertTitled:@"Bluetooth LE Support" messageBody:message];
+    if ([delegate respondsToSelector:@selector(shouldDisplayAlertTitled:messageBody:)]) {
+        [delegate shouldDisplayAlertTitled:@"Bluetooth LE Support" messageBody:message];
+    }
 
     return NO;
 }
@@ -184,7 +186,9 @@ static CBUUID *service_uuid;
     if (error.code) {
         cancelBlock = block;
 
-        [delegate shouldDisplayAlertTitled:@"Peripheral Disconnected with Error" messageBody:error.description];
+        if ([delegate respondsToSelector:@selector(shouldDisplayAlertTitled:messageBody:)]) {
+            [delegate shouldDisplayAlertTitled:@"Peripheral Disconnected with Error" messageBody:error.description];
+        }
         
     }
     else
@@ -265,7 +269,9 @@ static CBUUID *service_uuid;
 {
     NSLog(@"didFailToConnectPeripheral");
 
-    [delegate shouldDisplayAlertTitled:@"Connect Failed" messageBody:error.description];
+    if ([delegate respondsToSelector:@selector(shouldDisplayAlertTitled:messageBody:)]) {
+        [delegate shouldDisplayAlertTitled:@"Connect Failed" messageBody:error.description];
+    }
 }
 
 - (void)centralManager:(CBCentralManager *)central didRetrieveConnectedPeripherals:(NSArray *)peripherals

--- a/iPhone Apps/rfduino/RfduinoManager.m
+++ b/iPhone Apps/rfduino/RfduinoManager.m
@@ -98,16 +98,7 @@ static CBUUID *service_uuid;
             
     }
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Bluetooth LE Support"
-                                                    message:message
-                                                   delegate:nil
-                                          cancelButtonTitle:@"OK"
-                                          otherButtonTitles:nil];
-    [alert show];
-
-#endif
+    [delegate shouldDisplayAlertTitled:@"Bluetooth LE Support" messageBody:message];
 
     return NO;
 }
@@ -193,16 +184,7 @@ static CBUUID *service_uuid;
     if (error.code) {
         cancelBlock = block;
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-        
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Peripheral Disconnected with Error"
-                                                        message:error.description
-                                                       delegate:self
-                                              cancelButtonTitle:@"OK"
-                                              otherButtonTitles:nil];
-        [alert show];
-        
-#endif
+        [delegate shouldDisplayAlertTitled:@"Peripheral Disconnected with Error" messageBody:error.description];
         
     }
     else
@@ -229,9 +211,9 @@ static CBUUID *service_uuid;
     // NSLog(@"didDiscoverPeripheral");
 
     NSString *uuid = NULL;
-    if (peripheral.UUID) {
+    if ([peripheral.identifier.UUIDString length] > 0) {
         // only returned if you have connected to the device before
-        uuid = (__bridge_transfer NSString *)CFUUIDCreateString(NULL, peripheral.UUID);
+        uuid = peripheral.identifier.UUIDString;
     } else {
         uuid = @"";
     }
@@ -259,7 +241,7 @@ static CBUUID *service_uuid;
     id manufacturerData = [advertisementData objectForKey:CBAdvertisementDataManufacturerDataKey];
     if (manufacturerData) {
         const uint8_t *bytes = [manufacturerData bytes];
-        int len = [manufacturerData length];
+        NSUInteger len = [manufacturerData length];
         // skip manufacturer uuid
         NSData *data = [NSData dataWithBytes:bytes+2 length:len-2];
         rfduino.advertisementData = data;
@@ -283,17 +265,7 @@ static CBUUID *service_uuid;
 {
     NSLog(@"didFailToConnectPeripheral");
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Connect Failed"
-                                                    message:error.description
-                                                   delegate:nil
-                                          cancelButtonTitle:@"OK"
-                                          otherButtonTitles:nil];
-    [alert show];
-
-#endif
-
+    [delegate shouldDisplayAlertTitled:@"Connect Failed" messageBody:error.description];
 }
 
 - (void)centralManager:(CBCentralManager *)central didRetrieveConnectedPeripherals:(NSArray *)peripherals
@@ -302,26 +274,13 @@ static CBUUID *service_uuid;
 
 - (void)centralManagerDidUpdateState:(CBCentralManager *)aCentral
 {
-    NSLog(@"central manager state = %d", [central state]);
+    NSLog(@"central manager state = %ld", [central state]);
     
     bool success = [self isBluetoothLESupported];
     if (success) {
         [self startScan];
     }
 }
-
-#pragma mark - UIAlertViewDelegate methods
-
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-
-- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger) buttonIndex
-{
-    if (buttonIndex == 0) {
-        cancelBlock();
-    }
-}
-
-#endif
 
 #pragma mark - Rfduino methods
 


### PR DESCRIPTION
First issue - when adding the RFduino classes to a Swift project, UIKit is not available to RFduinoManager. It shouldn't really be anyway - instead I added an optional method to RFduinoManagerDelegate to request that the user of the manager display a message *if it wishes*.
Second, after iOS 7.1 CBPeripheral's uuid attribute is deprecated. Used peripheral.identifier.UUIDString instead of peripheral.UUID. 
Third, fixed a couple of type warnings.