### PR TITLE
Removing deprecated field in iOS framework and sample projects

### DIFF
--- a/iPhone Apps/rfduino/RFduino.h
+++ b/iPhone Apps/rfduino/RFduino.h
@@ -55,7 +55,6 @@ extern NSString *customUUID;
 @property(strong, nonatomic) RFduinoManager *rfduinoManager;
 
 @property(strong, nonatomic) NSString *name;
-@property(strong, nonatomic) NSString *UUID;
 @property(strong, nonatomic) NSData *advertisementData;
 @property(strong, nonatomic) NSNumber *advertisementRSSI;
 @property(assign, nonatomic) NSInteger advertisementPackets;

--- a/iPhone Apps/rfduino/RFduino.m
+++ b/iPhone Apps/rfduino/RFduino.m
@@ -90,7 +90,6 @@ static void incrementUuid16(CBUUID *uuid, unsigned char amount)
 @synthesize peripheral;
 
 @synthesize name;
-@synthesize UUID;
 @synthesize advertisementData;
 @synthesize advertisementRSSI;
 @synthesize advertisementPackets;

--- a/iPhone Apps/rfduino/RfduinoManager.m
+++ b/iPhone Apps/rfduino/RfduinoManager.m
@@ -227,15 +227,6 @@ static CBUUID *service_uuid;
 - (void)centralManager:(CBCentralManager *)central didDiscoverPeripheral:(CBPeripheral *)peripheral advertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber *)RSSI
 {
     // NSLog(@"didDiscoverPeripheral");
-
-    NSString *uuid = NULL;
-    if (peripheral.UUID) {
-        // only returned if you have connected to the device before
-        uuid = (__bridge_transfer NSString *)CFUUIDCreateString(NULL, peripheral.UUID);
-    } else {
-        uuid = @"";
-    }
-    
     bool added = false;
 
     RFduino *rfduino = [self rfduinoForPeripheral:peripheral];
@@ -245,7 +236,6 @@ static CBUUID *service_uuid;
         rfduino.rfduinoManager = self;
 
         rfduino.name = peripheral.name;
-        rfduino.UUID = uuid;
         
         rfduino.peripheral = peripheral;
         

--- a/iPhone Apps/rfduino/ScanViewController.m
+++ b/iPhone Apps/rfduino/ScanViewController.m
@@ -132,9 +132,6 @@
     if (rfduino.outOfRange) {
         start = [UIColor colorWithRed:160/255.0 green:160/255.0 blue:160/255.0 alpha:0.8];
         stop = [UIColor colorWithRed:160/255.0 green:160/255.0 blue:160/255.0 alpha:0.2];
-    } else if (! rfduino.UUID.length) {
-        start = [UIColor colorWithRed:224/255.0 green:242/255.0 blue:224/255.0 alpha: 1.0];
-        stop = [UIColor colorWithRed:224/255.0 green:242/255.0 blue:224/255.0 alpha: 0.7];
     } else {
         start = [UIColor colorWithRed:253/255.0 green:255/255.0 blue:255/255.0 alpha: 1.0];
         stop = [UIColor colorWithRed:253/255.0 green:255/255.0 blue:255/255.0 alpha: 0.7];
@@ -146,8 +143,6 @@
     cell.backgroundView = ccb;
     
     NSString *text = [[NSString alloc] initWithFormat:@"%@", rfduino.name];
-    
-    NSString *uuid = rfduino.UUID;
     
     int rssi = rfduino.advertisementRSSI.intValue;
 
@@ -162,7 +157,6 @@
         [detail appendString:@" "];
     [detail appendFormat:@"Packets: %d\n", rfduino.advertisementPackets];
     [detail appendFormat:@"Advertising: %@\n", advertising];
-    [detail appendFormat:@"%@", uuid];
     
     cell.textLabel.text = text;
     cell.detailTextLabel.text = detail;


### PR DESCRIPTION
iOS 8.x & above no longer use UUID. It's recommended that new projects no longer use UUID or identifier.