### PR TITLE
Updating README.md to show what's compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * Get the [RFduino hardware](http://RFduino.com).
 
-* Download [Arduino 1.5](http://arduino.cc/en/Main/Software).
+* Download [Arduino 1.5](http://arduino.cc/en/Main/OldSoftwareReleases) (The latest version, 1.6.3, is not compatible at this time).
   * _If you're on OSX_: Remember to open Arduino _first_ to make gatekeeper perform its magic!
 
 * Copy the Arduino library into the appropriate directory for your system. (Folder should be named ```RFduino```, not ```RFduino-master```):


### PR DESCRIPTION
Updating the README.md to specify that the latest version (1.6.3)  is not compatible (See Issue #17), and directing the users to the archive list which has the compatible versions (namely anything in the 1.5 release family).