### PR TITLE
Enable C++11 support when building

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -13,13 +13,13 @@ name=RFduino Boards
 
 compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os -w -ffunction-sections -fdata-sections -fno-builtin -MMD
+compiler.c.flags=-c -g -Os -w -std=gnu11 -ffunction-sections -fdata-sections -fno-builtin -MMD
 compiler.c.elf.cmd=arm-none-eabi-g++
 # -u _printf_float
 compiler.c.elf.flags=-Wl,--gc-sections --specs=nano.specs
 compiler.S.flags=-c -g -assembler-with-cpp
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -Os -w -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions -fno-builtin -MMD
+compiler.cpp.flags=-c -g -Os -w -std=gnu++11 -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions -fno-builtin -MMD
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy


### PR DESCRIPTION
FastLED is getting ready to move to fully supporting/making use of C++11 features.  Of the platforms that I'm building/testing for, RFDuino is the one that hasn't enabled C++11/C11 support in the compiler flags.
