### PR TITLE
Fixed Print::printf("%f") with correct digits

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -346,6 +346,9 @@ size_t Print::printf(const char *format, ...)
         if (l < 1)
           l = -l;
         l %= 100;
+        if(l < 10){
+         n += print(0);
+        }
         n += print(l);
       }
     }


### PR DESCRIPTION
Original printf() function for the float format (%f) outputs wrong number of digits after the decimal point (eg 1.02 is printed as 1.2).

This PR fixes this hidden bug in the library which is not easy for the users to find out...